### PR TITLE
(SIMP-5849)Timezone updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,70 @@
-sudo: false
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2017.2   4.10.4  2.1.9  TBD
+---
 language: ruby
 cache: bundler
-bundler_args: --without system_tests development
-before_install:
-- bundle -v
-- rm Gemfile.lock || true
-- gem update --system
-- gem update bundler
-- gem --version
-- bundle -v
-script:
-- bundle exec rake $CHECK
-matrix:
-  fast_finish: true
-  include:
-  - rvm: 2.2
-    env: PUPPET_VERSION="~> 4.7" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.4.4
-    env: PUPPET_VERSION="~> 5.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.7" STRICT_VARIABLES="yes" CHECK=rubocop
-  - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.7" STRICT_VARIABLES="yes" CHECK=build FORGEDEPLOY=true
+sudo: false
+
+bundler_args: --without development system_tests --path .vendor
+
 notifications:
   email: false
-deploy:
-  provider: puppetforge
-  user: saz
-  password:
-    secure: VlSGdU3hHTPHYe+++BOrnVcZE8rFHEYtByHoymvbf++dZaGv1RgCYVGr2Vn33gaT/h4hho8rgRyep5F6sHJaDPZUprJ5WU3I/TnbQrm13C521Z2+PP5jhEjG9rMHze4+4vDVKdO8K9x0zErGDwHaf6+QF5lQH6ewIykLWXl0DRA=
-  on:
-    tags: true
-    all_branches: true
-    rvm: 2.3.1
-    condition: "$FORGEDEPLOY = true"
+
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  include:
+    - stage: check
+      rvm: 2.4.4
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
+      script:
+        - bundle exec rake check:dot_underscore
+        - bundle exec rake pkg:check_version
+        - bundle exec rake metadata_lint
+        - bundle exec rake compare_latest_tag
+        - bundle exec puppet module build
+
+    - stage: spec
+      rvm: 2.4.4
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.4"
+      script:
+        - bundle exec rake spec
+
+    # This needs to be last since we have an acceptance test
+    - stage: deploy
+      rvm: 2.4.4
+      script:
+        - true
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+      deploy:
+        - provider: releases
+          api_key:
+            secure: "JvePksE1tLcRP93AuDqA1+mt7rJuEytBtm4QSsFd1qC2yxWZIF1q3Dzic+nqEgZlCNHa6lv2Tdk17uiZh/7Ct7lEKT+mKtgQveNvgOQ4PevrX4ueLBtLebwBBd/LDpWA+yIlrLKdwbg46KvWnMF5bDE4ZYoOb7eDc/5VaK3Foujn/JuOLzdN7xabLZRJxJRSzdjlYGRCqIWcvMW7dby91wMgjeB01gOIHIOisKfIMG3GIHMBeao5eir0K13ATdvosBByte/xOfPymapMq4bz8YuOMUVqG+9uXQsVfVXNF5rmIFfZis0BQFVSq6LfgakJN2dHolS49sI/fXJaCUyuwUd6Ipd2klsZ3SkRw2XGO68FNaKIckELNV2gbhZkBLo5TvZflU8LGwTzG2MZCIAzpN3rjXy4alG203YDNmO9abyse5BBPKWUBm96A68TVffE0mq9v9lUaZkJdsIhJQFMrkyCj9wkxpODGSHMMZXhjOK4lR+ySXo2h/kD48SrNkHvfn4TqeP/c/u7dnTzhTVLAMaLcqX1ZdBjz4VExtSwsHYOcqDss8NMeQ0aQIC1zPhoOpW91fflBnREG1XTfQY49vIqR/m+vgllgPh03p/SN+LFuYLhg7Yzl3HwC2afrjVDxUXMz6dWb/rQwGTtssXixWgUL2xGrskbk/J7n1pHy/o="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+            secure: "J1UQKsQ6bMntRJwr+RSTFOMAeU5+nEcliPui12pZ0hReA0Jnta2E7LffA4Q0rdishA2bh8vSgz44UM+FTjbKaDcnIXlfbAEs38D6btKWSpmvN8ylfETNJM/LePrkb41VZKK7kFO0UObVy6JhOCpxLhynv2DQpmN9du+e4jhYQwmlW5Y+93yTqPIba4cbLxpVW9IMvMVC21W/P4Mk8orYjYslAQJS4vDrQf3poNRMoYiyhyu/Zc109SCETgd+T+TKwnM/yWzCC58nsEdg2q74WdPsdKwc4weFrshwllCnWjOXjjpXN6iId6BGmUoquxL5Jsry0fcEwvZdhB2Yc4AuJbd7j+oBx7lnvJcIM+0hbVgdeBx9p24vkht6axhlJ9JxfqWmIfNe/J4pyWaXTK1gasmMBOqutY8nmO6NJV5kFJ857ci3XcczR46RyurYMVms+ZPyi+G7wmCivQ/cpyQSc6jO6YjzA+DXlKlBKkoyL8r47XuhBtGSwv5ZpGKdWpzesfOCfPzXHTSuDnZ88+LfJ1kBoiEp4CuhD/olKHmPz/7HKEUIA++NoHtIp8puazM3kKCOCQNEzGQx+wcstJyblvBuqXAXT01WHx1MYpADjbZGQX0heNSYawSc5EEIa+r5BgKYaNKFxrGuRume376zEwm2n1ptnM6AbnWt4dalSqY="
+          on:
+            tags: true
+            rvm: 2.4.1
+            condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,10 @@
+* Fri Dec 07 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.0.3-0
+- Centos 7.5 expects localtime to be a link and errors out.
+- updated gemfile to work with beaker 4 and 3
+
+* Thu Oct 11 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.2-0
+- Bump to support Puppet 5
+- Jumped to 5.0.2 to skip past the upstream version numbers
+
+* Thu Sep 28 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.0.0-0
+- Initial fork of saz-timezone with Puppet 4+ support

--- a/Gemfile
+++ b/Gemfile
@@ -1,60 +1,32 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+# ------------------------------------------------------------------------------
+# NOTE: SIMP Puppet rake tasks support ruby 2.1.9
+# ------------------------------------------------------------------------------
+gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
-def location_for(place, fake_version = nil)
-  if place =~ /^(git[:@][^#]*)#(.*)/
-    [fake_version, { git: Regexp.last_match(1), branch: Regexp.last_match(2), require: false }].compact
-  elsif place =~ /^file:\/\/(.*)/
-    ['>= 0', { path: File.expand_path(Regexp.last_match(1)), require: false }]
-  else
-    [place, { require: false }]
-  end
-end
+gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  gem 'puppetlabs_spec_helper',                                     require: false
-  gem 'rspec-puppet',                                               require: false
-  gem 'rspec-puppet-facts',                                         require: false
-  gem 'rspec-puppet-utils',                                         require: false
-  gem 'puppet-lint-absolute_classname-check',                       require: false
-  gem 'puppet-lint-leading_zero-check',                             require: false
-  gem 'puppet-lint-trailing_comma-check',                           require: false
-  gem 'puppet-lint-version_comparison-check',                       require: false
-  gem 'puppet-lint-classes_and_types_beginning_with_digits-check',  require: false
-  gem 'puppet-lint-unquoted_string-check',                          require: false
-  gem 'puppet-lint-variable_contains_upcase',                       require: false
-  gem 'metadata-json-lint',                                         require: false
-  gem 'puppet-blacksmith',                                          require: false
-  gem 'voxpupuli-release',                                          require: false, git: 'https://github.com/voxpupuli/voxpupuli-release-gem.git'
-  gem 'rubocop-rspec', '~> 1.5',                                    require: false if RUBY_VERSION >= '2.2.0'
-  gem 'json_pure', '<= 2.0.1',                                      require: false if RUBY_VERSION < '2.0.0'
-  gem 'rspec-its',                                                  require: false
+  gem 'rake'
+  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~> 5.5')
+  gem 'rspec'
+  gem 'rspec-puppet'
+  gem 'hiera-puppet-helper'
+  gem 'puppetlabs_spec_helper'
+  gem 'metadata-json-lint'
+  gem 'puppet-strings'
+  gem 'puppet-lint-empty_string-check',   :require => false
+  gem 'puppet-lint-trailing_comma-check', :require => false
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.2')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.6')
 end
 
 group :development do
-  gem 'travis',       require: false
-  gem 'travis-lint',  require: false
-  gem 'guard-rake',   require: false
+  gem 'pry'
+  gem 'pry-doc'
 end
 
 group :system_tests do
-  if (beaker_version = ENV['BEAKER_VERSION'])
-    gem 'beaker', *location_for(beaker_version)
-  end
-  if (beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION'])
-    gem 'beaker-rspec', *location_for(beaker_rspec_version)
-  else
-    gem 'beaker-rspec', require: false
-  end
-  gem 'beaker-puppet_install_helper', require: false
+  gem 'beaker'
+  gem 'beaker-rspec'
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '>= 1.13.0')
 end
-
-if (facterversion = ENV['FACTER_GEM_VERSION'])
-  gem 'facter', facterversion.to_s, require: false, groups: [:test]
-else
-  gem 'facter', require: false, groups: [:test]
-end
-
-ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 4.0' : puppetversion = ENV['PUPPET_VERSION'].to_s
-gem 'puppet', puppetversion, require: false, groups: [:test]
-
-# vim: syntax=ruby

--- a/README.md
+++ b/README.md
@@ -1,5 +1,40 @@
 # puppet-timezone [![Build Status](https://secure.travis-ci.org/saz/puppet-timezone.png)](http://travis-ci.org/saz/puppet-timezone)
 
+----
+
+THIS IS A FORK OF THE MODULE AND WILL REVERT TO THE ORIGINAL MODULE ONCE THE
+SIMP PACKAGING SYSTEM HAS BEEN UPDATED.
+
+The fork includes the following minor changes that are related to publishing
+and maintenance:
+ - .travis.yml   => Modified to work with the SIMP publishing process
+ - CHANGELOG     => Added to work with the SIMP RPM building
+ - Gemfile       => updated to require gems that work with beaker 3 and 4 and
+                 allow testing for puppet4/5 and 6.
+ - README.md     => These modifications
+ - Rakefile      => Modified with the standard SIMP rake tasks
+ - metadata.json => Modified namespace and Puppet 5 support
+ - tests/init.pp => Removed per modern Puppet best practice
+ - manifests/init.pp =>  Updated file resource for localtime_file to use
+                 target attribute and the added this file resource as
+                 as a requirement for running timedate command so the
+                 file would be in the proper format.
+ - spec/classes/timezone_spec.rb
+                 => updated tests to reflect changes in manifests/init.pp
+ - spec/acceptence/timezone_spec.rb
+                 => added test,
+ - spec/acceptence/nodeset/*.yml
+                 => updated the nodesets so they work with puppet 5 and added
+                 a nodeset, centos-6.yml
+ - data/os/RedHat/7.yml => updated the file name for timezone definitions to
+                 make puppet run idempotent because centos 7 use a relative path.
+
+A pull request has been submitted forthe puppet code that was modified.
+ Original work is copyright Steffen Zieger.
+
+ New modifications are copyright Onyx Point, Inc.
+
+
 Manage timezone settings via Puppet
 
 ### Supported Puppet versions

--- a/Rakefile
+++ b/Rakefile
@@ -1,42 +1,9 @@
-require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet_blacksmith/rake_tasks'
-require 'voxpupuli/release/rake_tasks'
+require 'simp/rake/pupmod/helpers'
+require 'puppet-strings/tasks'
 
-if RUBY_VERSION >= '2.2.0'
-  require 'rubocop/rake_task'
-
-  RuboCop::RakeTask.new(:rubocop) do |task|
-    # These make the rubocop experience maybe slightly less terrible
-    task.options = ['-D', '-S', '-E']
-  end
-end
-
-PuppetLint.configuration.fail_on_warnings = true
-PuppetLint.configuration.send('relative')
-PuppetLint.configuration.send('disable_140chars')
-PuppetLint.configuration.send('disable_class_inherits_from_params_class')
-PuppetLint.configuration.send('disable_documentation')
-PuppetLint.configuration.send('disable_single_quote_string_with_variables')
-
-exclude_paths = %w(
-  pkg/**/*
-  vendor/**/*
-  .vendor/**/*
-  spec/**/*
-)
-PuppetLint.configuration.ignore_paths = exclude_paths
-PuppetSyntax.exclude_paths = exclude_paths
+Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
 
 desc 'Run acceptance tests'
 RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
-
-desc 'Run tests metadata_lint, lint, syntax, spec'
-task test: [
-  :metadata_lint,
-  :lint,
-  :syntax,
-  :spec
-]
-# vim: syntax=ruby

--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -4,3 +4,9 @@ timezone::timezone_update_check_cmd: 'timedatectl status | grep "Timezone:\|Time
 timezone::check_hwclock_enabled_cmd: 'grep LOCAL /etc/adjtime'
 timezone::check_hwclock_disabled_cmd: 'grep UTC /etc/adjtime'
 timezone::hwclock_cmd: 'timedatectl set-local-rtc %s'
+# timedatectl sets the link for local time to a relative path
+# If it is not set the same way, the timedatectl will change
+# it when it runs and it is not idempotent. Localtime_file was
+# added because zoneinfo_dir is relative to that.
+timezone::localtime_file: '/etc/localtime'
+timezone::zoneinfo_dir: '../usr/share/zoneinfo'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,7 +144,8 @@ class timezone (
 
   file { $localtime_file:
     ensure => $localtime_ensure,
-    source => "${zoneinfo_dir}/${timezone}",
+    target => "${zoneinfo_dir}/${timezone}",
+    force  => true,
     notify => $notify_services,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class timezone (
       } else {
         $package_ensure = 'present'
       }
-      $localtime_ensure = 'file'
+      $localtime_ensure = 'link'
       $timezone_ensure = 'file'
     }
     /(absent)/: {
@@ -144,8 +144,7 @@ class timezone (
 
   file { $localtime_file:
     ensure => $localtime_ensure,
-    source => "file://${zoneinfo_dir}/${timezone}",
-    links  => follow,
+    source => "${zoneinfo_dir}/${timezone}",
     notify => $notify_services,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,6 +109,7 @@ class timezone (
         command     => sprintf($timezone_update, $timezone),
         subscribe   => File[$timezone_file],
         refreshonly => true,
+        require     => File[$localtime_file],
         path        => '/usr/bin:/usr/sbin:/bin:/sbin',
       }
     }
@@ -118,6 +119,7 @@ class timezone (
       exec { 'update_timezone':
         command => sprintf($timezone_update, $timezone),
         unless  => sprintf($unless_cmd, $timezone),
+        require => File[$localtime_file],
         path    => '/usr/bin:/usr/sbin:/bin:/sbin',
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,4 +1,22 @@
 {
+  "name": "simp-timezone",
+  "version": "5.0.3",
+  "source": "git://github.com/simp/pupmod-simp-timezone",
+  "author": "SIMP Team",
+  "license": "Apache-2.0",
+  "summary": "Manage timezone settings via Puppet",
+  "description": "Manage timezone settings via Puppet",
+  "project_page": "https://github.com/simp/pupmod-simp-timezone",
+  "dependencies": [
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.6.0 < 5.0.0" },
+    { "name": "stm/debconf", "version_requirement": ">= 2.0.0 < 3.0.0" }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.9.1 < 6.0.0"
+    }
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat"
@@ -24,23 +42,5 @@
     {
       "operatingsystem": "ArchLinux"
     }
-  ],
-  "requirements": [
-    {
-      "name": "puppet",
-      "version_requirement": ">= 4.9.1 < 6.0.0"
-    }
-  ],
-  "name": "saz-timezone",
-  "version": "5.0.2",
-  "source": "git://github.com/saz/puppet-timezone",
-  "author": "saz",
-  "license": "Apache-2.0",
-  "summary": "Manage timezone settings via Puppet",
-  "description": "Manage timezone settings via Puppet",
-  "project_page": "https://github.com/saz/puppet-timezone",
-  "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.6.0 < 5.0.0" },
-    { "name": "stm/debconf", "version_requirement": ">= 2.0.0 < 3.0.0" }
   ]
 }

--- a/spec/acceptance/nodesets/centos-6.yml
+++ b/spec/acceptance/nodesets/centos-6.yml
@@ -1,8 +1,8 @@
 HOSTS:
-  centos-7:
-    platform: el-7-x86_64
+  centos-6:
+    platform: el-6-amd64
     hypervisor : docker
-    image: centos:7
+    image: centos:6
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
@@ -12,3 +12,4 @@ CONFIG:
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>
+

--- a/spec/acceptance/timezone_spec.rb
+++ b/spec/acceptance/timezone_spec.rb
@@ -1,15 +1,30 @@
 require 'spec_helper_acceptance'
 
 describe 'timezone class' do
+
   describe 'running puppet code' do
     it 'works with no errors' do
       pp = <<-PUPPET
-        class { '::timezone': }
+        class { '::timezone': timezone => 'Europe/Rome'}
       PUPPET
-
       # Run it twice and test for idempotency
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+      apply_manifest( pp, :catch_failures => true)
+      apply_manifest( pp, :catch_changes => true)
+#          result=on(host,%(ls -la /etc/localtime))
+#          expect(result.output).to match(%r(/usr/share))
+    end
+  end
+  describe 'with /etc/localtime an existing file' do
+    it 'can update timezone if localtime is not a link' do
+      result =  %(unlink /etc/localtime ; touch /etc/localtime)
+      check_file = %(ls -la /etc/localtime)
+      expect(check_file).to_not match(%r(->))
+      px = <<-PUPPET
+      class { '::timezone': timezone => 'Europe/Berlin'}
+      PUPPET
+      # Run it twice and test for idempotency
+      apply_manifest( px, :catch_failures => true)
+      apply_manifest( px, :catch_changes => true)
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,9 @@
 require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
 
-install_puppet_on hosts
+
+run_puppet_install_helper
+#install_puppet_on hosts
 
 RSpec.configure do |c|
   module_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
@@ -15,6 +18,7 @@ RSpec.configure do |c|
     puppet_module_install(:source => module_root, :module_name => module_name)
     hosts.each do |host|
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), :acceptable_exit_codes => [0, 1]
+      on host, puppet('module', 'install', 'stm/debconf'), :acceptable_exit_codes => [0, 1]
     end
   end
 end

--- a/spec/support/debian.rb
+++ b/spec/support/debian.rb
@@ -16,7 +16,10 @@ shared_examples 'Debian' do
     it { is_expected.to contain_file('/etc/timezone') }
     it { is_expected.to contain_file('/etc/timezone').with_ensure('file') }
     it { is_expected.to contain_file('/etc/timezone').with_content(%r{Etc/UTC}) }
-    it { is_expected.to contain_exec('update_timezone').with_command(%r{^dpkg-reconfigure -f noninteractive tzdata$}) }
+    it { is_expected.to contain_exec('update_timezone').with({
+      'command' => %r{^dpkg-reconfigure -f noninteractive tzdata$},
+      'require' => 'File[/etc/localtime]'
+    })}
 
     it do
       is_expected.to contain_package('tzdata').with(:ensure => 'present',

--- a/spec/support/debian.rb
+++ b/spec/support/debian.rb
@@ -24,14 +24,14 @@ shared_examples 'Debian' do
     end
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/debian.rb
+++ b/spec/support/debian.rb
@@ -23,15 +23,15 @@ shared_examples 'Debian' do
                                                     :before => 'File[/etc/localtime]')
     end
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/freebsd.rb
+++ b/spec/support/freebsd.rb
@@ -14,14 +14,14 @@ shared_examples 'FreeBSD' do
     it { is_expected.to create_class('timezone') }
 
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/freebsd.rb
+++ b/spec/support/freebsd.rb
@@ -15,13 +15,13 @@ shared_examples 'FreeBSD' do
 
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/gentoo.rb
+++ b/spec/support/gentoo.rb
@@ -26,14 +26,14 @@ shared_examples 'Gentoo' do
     it { is_expected.to contain_exec('update_timezone').with_command(%r{^emerge --config timezone-data$}) }
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/gentoo.rb
+++ b/spec/support/gentoo.rb
@@ -23,7 +23,10 @@ shared_examples 'Gentoo' do
 
     it { is_expected.to contain_file('/etc/timezone').with_ensure('file') }
     it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Etc/UTC$}) }
-    it { is_expected.to contain_exec('update_timezone').with_command(%r{^emerge --config timezone-data$}) }
+    it { is_expected.to contain_exec('update_timezone').with({
+      :command => %r{^emerge --config timezone-data$},
+      :require => 'File[/etc/localtime]'
+     })}
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
                                                          :target => '/usr/share/zoneinfo/Etc/UTC')

--- a/spec/support/gentoo.rb
+++ b/spec/support/gentoo.rb
@@ -25,15 +25,15 @@ shared_examples 'Gentoo' do
     it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Etc/UTC$}) }
     it { is_expected.to contain_exec('update_timezone').with_command(%r{^emerge --config timezone-data$}) }
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -24,15 +24,15 @@ shared_examples 'RedHat' do
     it { is_expected.not_to contain_exec('update_timezone') }
 
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/sysconfig/clock').with_content(%r{^ZONE="Europe/Berlin"$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do
@@ -66,7 +66,7 @@ shared_examples 'RedHat' do
 
     it { is_expected.to create_class('timezone') }
     it { is_expected.not_to contain_file('/etc/sysconfig/clock') }
-    it { is_expected.to contain_file('/etc/localtime').with_ensure('file') }
+    it { is_expected.to contain_file('/etc/localtime').with_ensure('link') }
     it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone Etc/UTC').with_unless('timedatectl status | grep "Timezone:\|Time zone:" | grep -q Etc/UTC') }
 
     include_examples 'validate parameters'

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -25,14 +25,14 @@ shared_examples 'RedHat' do
 
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/sysconfig/clock').with_content(%r{^ZONE="Europe/Berlin"$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -67,7 +67,11 @@ shared_examples 'RedHat' do
     it { is_expected.to create_class('timezone') }
     it { is_expected.not_to contain_file('/etc/sysconfig/clock') }
     it { is_expected.to contain_file('/etc/localtime').with_ensure('link') }
-    it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone Etc/UTC').with_unless('timedatectl status | grep "Timezone:\|Time zone:" | grep -q Etc/UTC') }
+    it { is_expected.to contain_exec('update_timezone').with({
+      :command => 'timedatectl set-timezone Etc/UTC',
+      :unless  => 'timedatectl status | grep "Timezone:\|Time zone:" | grep -q Etc/UTC',
+      :require => 'File[/etc/localtime]'
+    })}
 
     include_examples 'validate parameters'
   end


### PR DESCRIPTION
      - Updated timezone to latest unreleased version.
      - Added `require` for exec to make sure localtime file
        was updated and a link, file was a link first.
        (timedatectl fails if it is not)
      - Added nodeset for centos6.
      - Update Gemfile so tests would work with beaker 3 or 4.
      - created gitlab-ci.yml to make running acceptance test easier.

    SIMP-5849 #close
