### PR TITLE
(SIMP-5849) Update Timezone

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Dec 07 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.0.3-0
+- Pulled latest fixes from saz time zone.  Needed for Centos 7.5 which
+  requires localtime to be a link.
+
 * Thu Oct 11 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.2-0
 - Bump to support Puppet 5
 - Jumped to 5.0.2 to skip past the upstream version numbers

--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@
 >
 > The fork includes the following minor changes that are related to publishing
 > and maintenance:
->   - .travis.yml   => Modified to work with the SIMP publishing process
->   - CHANGELOG     => Added to work with the SIMP RPM building
->   - README.md     => These modifications
->   - Rakefile      => Modified with the standard SIMP rake tasks
->   - metadata.json => Modified namespace and Puppet 5 support
->   - tests/init.pp => Removed per modern Puppet best practice
->
-> None of the actual Puppet code has been modified from the original and the
-> original work is copyright Steffen Zieger.
+>   - .travis.yml       => Modified to work with the SIMP publishing process
+>   - CHANGELOG         => Added to work with the SIMP RPM building
+>   - README.md         => These modifications
+>   - Rakefile          => Modified with the standard SIMP rake tasks
+>   - metadata.json     => Modified namespace and Puppet 5 support
+>   - tests/init.pp     => Removed per modern Puppet best practice
+>   - manifests/init.pp => updated with latest fixes and added a require statement
+>                          for /etc/localtime when running timezone update to ensure
+>                          /etc/localtime is a link.
+>   - spec/support/*    => tests for the changes in manifests/init.pp
 >
 > New modifications are copyright Onyx Point, Inc.
 >

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class timezone (
       } else {
         $package_ensure = 'present'
       }
-      $localtime_ensure = 'file'
+      $localtime_ensure = 'link'
       $timezone_ensure = 'file'
     }
     /(absent)/: {
@@ -109,6 +109,7 @@ class timezone (
         command     => sprintf($timezone_update, $timezone),
         subscribe   => File[$timezone_file],
         refreshonly => true,
+        require     => File[$localtime_file],
         path        => '/usr/bin:/usr/sbin:/bin:/sbin',
       }
     }
@@ -118,6 +119,7 @@ class timezone (
       exec { 'update_timezone':
         command => sprintf($timezone_update, $timezone),
         unless  => sprintf($unless_cmd, $timezone),
+        require => File[$localtime_file],
         path    => '/usr/bin:/usr/sbin:/bin:/sbin',
       }
     }
@@ -144,8 +146,7 @@ class timezone (
 
   file { $localtime_file:
     ensure => $localtime_ensure,
-    source => "file://${zoneinfo_dir}/${timezone}",
-    links  => follow,
+    target => "${zoneinfo_dir}/${timezone}",
     notify => $notify_services,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-timezone",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "source": "git://github.com/simp/pupmod-simp-timezone",
   "author": "SIMP Team",
   "license": "Apache-2.0",

--- a/spec/support/debian.rb
+++ b/spec/support/debian.rb
@@ -23,15 +23,15 @@ shared_examples 'Debian' do
                                                     :before => 'File[/etc/localtime]')
     end
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/freebsd.rb
+++ b/spec/support/freebsd.rb
@@ -14,14 +14,14 @@ shared_examples 'FreeBSD' do
     it { is_expected.to create_class('timezone') }
 
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/gentoo.rb
+++ b/spec/support/gentoo.rb
@@ -25,15 +25,15 @@ shared_examples 'Gentoo' do
     it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Etc/UTC$}) }
     it { is_expected.to contain_exec('update_timezone').with_command(%r{^emerge --config timezone-data$}) }
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -24,15 +24,15 @@ shared_examples 'RedHat' do
     it { is_expected.not_to contain_exec('update_timezone') }
 
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/sysconfig/clock').with_content(%r{^ZONE="Europe/Berlin"$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do
@@ -66,7 +66,7 @@ shared_examples 'RedHat' do
 
     it { is_expected.to create_class('timezone') }
     it { is_expected.not_to contain_file('/etc/sysconfig/clock') }
-    it { is_expected.to contain_file('/etc/localtime').with_ensure('file') }
+    it { is_expected.to contain_file('/etc/localtime').with_ensure('link') }
     it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone Etc/UTC').with_unless('timedatectl status | grep "Timezone:\|Time zone:" | grep -q Etc/UTC') }
 
     include_examples 'validate parameters'


### PR DESCRIPTION
- Pulled latest fixes from saz/timezone.  These create /etc/localtime
  as link.  In CentOS 7.5 if  that file is not a link then timezone
  update fails.

SIMP-5849 #close